### PR TITLE
change gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,6 @@ build/
 develop-eggs/
 dist/
 eggs/
-lib/
 lib64/
 parts/
 sdist/


### PR DESCRIPTION
I just discovered, to my horror, that the `frontend/src/lib` is not tracked by git because of this line in the root folder. Seems like copy and pasting code I found online isn't really a good idea 😭. @Daniel5055 Do you need this? If not, please just merge it. 
