### PR TITLE
Use State to Get New Submission

### DIFF
--- a/executioner/src/interfaces/firestore-interface.mjs
+++ b/executioner/src/interfaces/firestore-interface.mjs
@@ -39,8 +39,7 @@ export async function initFirestoreInterface(options) {
   return {
     onSubmission: (handleSubmission) => {
       submissions
-        .where('judged', '==', false)
-        .where('error', '==', false)
+        .where('state', '==', 'queued')
         .onSnapshot((snapshot) => {
           // Skip the first if not readOld and trigger flag to read rest
           if (!readOld && !readOldYet) {


### PR DESCRIPTION
We will not use `judged` and `error` so the current method of getting new submission will not work. Please see if there are other places that need to be changed. 

Also added the `queued` state, which previously was just undefined for `state` because it is impossible to get all the document with `state` undefined. 
