### PR TITLE
fix #5: Syntax Highlighting for Resubmission

### DIFF
--- a/frontend/src/lib/MonacoBlock.svelte
+++ b/frontend/src/lib/MonacoBlock.svelte
@@ -42,6 +42,8 @@
 			value: '',
 			automaticLayout: true
 		});
+        if (language)
+            updateLanguage(language);
 
 		return () => {
 			editor.dispose();

--- a/frontend/src/lib/MonacoBlock.svelte
+++ b/frontend/src/lib/MonacoBlock.svelte
@@ -42,8 +42,7 @@
 			value: '',
 			automaticLayout: true
 		});
-        if (language)
-            updateLanguage(language);
+		if (language) updateLanguage(language);
 
 		return () => {
 			editor.dispose();


### PR DESCRIPTION
Resubmission actually create new Monaco editor but
language already set from previous editor so didn't
reactivate updateLanguage for new editor.