### PR TITLE
Created default compare answer function

### DIFF
--- a/executioner/src/executor.mjs
+++ b/executioner/src/executor.mjs
@@ -6,6 +6,7 @@ import path, { resolve } from 'path';
 import rl from 'readline';
 import { getSourceCodeFileName } from './utils/functions.mjs';
 import { InvalidDataError } from './utils/types/errors.mjs';
+import { compareAnswer } from './utils/compare.mjs';
 
 /*
 - This is where the actual execution of a request in a container occurs
@@ -315,11 +316,10 @@ export async function execute(
                   fs.readFile(answersFilePath),
                 ]);
 
-                // TODO: Not sure on how strict this comparison is
                 // TODO: Restrict usage to be at max resourece limits
 
                 // If the same
-                if (files[0].equals(files[1])) {
+                if (compareAnswer(files[0].toString(), files[1].toString())) {
                   // Parse data from info to send out
                   const infoLines = info.split('\n');
                   const [timeUsed] = infoLines[0].split(' ').slice(-1);
@@ -387,7 +387,13 @@ export async function execute(
       return message;
     }
 
-    let commandArgs = ['run', '--network', 'none', '-v', `${mountPath}:/app/mount`];
+    let commandArgs = [
+      'run',
+      '--network',
+      'none',
+      '-v',
+      `${mountPath}:/app/mount`,
+    ];
 
     // The constraints
     commandArgs.push('-e', `MAX_MEM=${maxMem}`);

--- a/executioner/src/interfaces/firestore-interface.mjs
+++ b/executioner/src/interfaces/firestore-interface.mjs
@@ -69,7 +69,7 @@ export function FirestoreInterface({
   this.sendMessage = createFirestoreMessageHandler(
     (id, data) => submissions.doc(id).update(data),
     (id, data) =>
-      submissions.doc(id).collection(submissionsJudgeResultPath).add(data),
+      submissions.doc(id).collection(submissionsJudgeResultPath).add(data)
   );
 }
 

--- a/executioner/src/utils/compare.mjs
+++ b/executioner/src/utils/compare.mjs
@@ -1,0 +1,12 @@
+// The default function used to compare a test result with an answer
+export function compareAnswer(result, answer) {
+  function cleanString(str) {
+    // Trim spaces on end and start of string
+    const trimmedStr = str.trim();
+
+    // Replace mutiple spaces with one
+    return trimmedStr.replace(/\s\s+/g, ' ');
+  }
+
+  return cleanString(answer) === cleanString(result);
+}

--- a/executioner/test/compare.test.mjs
+++ b/executioner/test/compare.test.mjs
@@ -1,0 +1,129 @@
+import test from 'ava';
+import { compareAnswer } from '../src/utils/compare.mjs';
+
+// Manual Unit testing of the default compareAnswer function in compare.mjs
+test('Comparing identical regular strings', (t) => {
+  const strings = [
+    'Aiguines',
+    'Gorge du Verdon',
+    'Sainte-Croix-du-Verdon',
+    'The D957',
+    "Chateau d'Aiguines",
+    'VAR & ALPES-DE-HAUTE-PROVENCE',
+    'y = 2x + 10^2 - (x % 2)',
+  ];
+
+  for (const str of strings) {
+    t.true(
+      compareAnswer(str, str),
+      `Comparing ${str} to itself returned false`
+    );
+  }
+});
+
+test('Comparing identical trimmable strings', (t) => {
+  const strings = [
+    ' Riez',
+    'Roumoules ',
+    ' Montagnac-Montpezat ',
+    'Chapelle   Saint-Maxime',
+    "    Camping   de l'Aigle  - Campasun     ",
+    '    1 vie   2 chiens',
+    'Chapelle Saint-Pierre  ',
+    ' 1 = 2  - 2+1 *    0 + 1  ',
+  ];
+
+  for (const str of strings) {
+    t.true(
+      compareAnswer(str, str),
+      `Comparing ${str} to itself returned false`
+    );
+  }
+});
+
+test('Comparing equivalent trimmed strings with non trimmed strings', (t) => {
+  const strings = [
+    [' Riez', 'Riez'],
+    ['Roumoules ', 'Roumoules'],
+    [' Montagnac-Montpezat ', 'Montagnac-Montpezat'],
+    ['Chapelle   Saint-Maxime', 'Chapelle Saint-Maxime'],
+    [
+      "    Camping   de l'Aigle  - Campasun     ",
+      "Camping de l'Aigle - Campasun",
+    ],
+    ['    1 vie   2 chiens', '1 vie 2 chiens'],
+    ['Chapelle Saint-Pierre  ', 'Chapelle Saint-Pierre'],
+    [' 1 = 2  - 2+1 *    0 + 1  ', '1 = 2 - 2+1 * 0 + 1'],
+  ];
+
+  for (const [trimmable, trimmed] of strings) {
+    t.true(
+      compareAnswer(trimmable, trimmed),
+      `Comparing ${trimmable} to ${trimmed} returned false`
+    );
+  }
+});
+
+test('Comparing trimmed strings with non trimmed strings using special whitespace', (t) => {
+  const strings = [
+    ['\tLac de Sainte-Croix\n', 'Lac de Sainte-Croix'],
+    ['\nBauden\n', 'Bauden'],
+    ['   Regusse\n', 'Regusse'],
+    ['\t\tQuinson  ', 'Quinson'],
+    ['Puimoisson\t&\t  Riez', 'Puimoisson\t& Riez'],
+    ['Tennison\t\t\n \ndanihe', 'Tennison danihe'],
+    ['Mo \n Na \t Co', 'Mo Na Co'],
+  ];
+
+  for (const [trimmable, trimmed] of strings) {
+    t.true(
+      compareAnswer(trimmable, trimmed),
+      `Comparing ${trimmable} to ${trimmed} returned false`
+    );
+  }
+});
+
+test('Comparing wrongly trimmed strings with non trimmed strings', (t) => {
+  const strings = [
+    ['Daniel\tBrathagen', 'Daniel Brathagen'],
+    ['S\tT\nA O J', 'S T A O J'],
+    ['S\nT A O\tJ', 'STAOJ'],
+    ['S    T A OJ  ', 'STAOJ'],
+    ['   STAO J', 'STAOJ'],
+    ['S\n\nTAOJ', 'STAOJ'],
+    ['S\t\tTAOJ', 'STAOJ'],
+    ['S  TAOJ', 'STAOJ'],
+    ['1 2 3 4', '1234'],
+    ['STAOJ', 'staoj'],
+    ['STAOJ', 'StAOJ'],
+    [' J', 'j'],
+  ];
+
+  for (const [nonTrimmable, trimmed] of strings) {
+    t.false(
+      compareAnswer(nonTrimmable, trimmed),
+      `Comparing ${nonTrimmable} to ${trimmed} returned true`
+    );
+  }
+});
+
+test('Comparing completely different strings', (t) => {
+  const strings = [
+    ['AJR', 'Quinn XCII'],
+    ['Jon', 'Bellion'],
+    ['12', '21'],
+    ['23', '23 23'],
+    ['2 3', '2323'],
+    ['2   3', '32'],
+    ['42', ''],
+    ['', '1000'],
+    ['Jonathon', 'Johnny'],
+  ];
+
+  for (const [str1, str2] of strings) {
+    t.false(
+      compareAnswer(str1, str2),
+      `Comparing ${str1} to ${str2} returned true`
+    );
+  }
+});


### PR DESCRIPTION
So I've created the default function to compare answers from a problem test case file with the result of submitted code as specified in #23. However, I am not sure how strict or lenient this comparison should be.

So far I have followed how JavaScript handles whitespace. That is, \n, \t, and ' ' are all considered whitespace (\s) and the `.trim()` function will remove those whitespaces from the start and end of strings. Furthermore, more than 1 whitespace together between non-whitespace characters will be trimmed to a single ' '. These are the only transformations I perform with strings before comparing them with JavaScripts' strict equal (===).

Examples what the function should and shouldn't compare to true are seen in the `compare.test.mjs` file.