### PR TITLE
Add podman build arg

### DIFF
--- a/executioner/package.json
+++ b/executioner/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "node start.mjs",
     "test": "ava --timeout=5m -c=4",
-    "postinstall": "podman build . -t executioner"
+    "postinstall": "podman build . -t executioner --cgroup-manager=cgroupfs"
   },
   "ava": {
     "files": [


### PR DESCRIPTION
If I don't use this arg, I get an error
```
$ npm install 

> executioner@0.9 postinstall
> podman build . -t executioner

WARN[0000] The cgroupv2 manager is set to systemd but there is no systemd user session available 
WARN[0000] For using systemd, you may need to login using an user session 
WARN[0000] Alternatively, you can enable lingering with: `loginctl enable-linger 1000` (possibly as root) 
WARN[0000] Falling back to --cgroup-manager=cgroupfs    
WARN[0000] The cgroupv2 manager is set to systemd but there is no systemd user session available 
WARN[0000] For using systemd, you may need to login using an user session 
WARN[0000] Alternatively, you can enable lingering with: `loginctl enable-linger 1000` (possibly as root) 
WARN[0000] Falling back to --cgroup-manager=cgroupfs    
STEP 1: FROM ubuntu:22.04
Resolved "ubuntu" as an alias (/etc/containers/registries.conf.d/shortnames.conf)
Getting image source signatures
Copying blob 4a3049d340b7 [------------------------------------] 0.0b / 0.0b
Copying config bad148f896 done  
Writing manifest to image destination
Storing signatures
STEP 2: RUN apt-get update
error running container: error creating container for [/bin/sh -c apt-get update]: sd-bus call: Permission denied
: exit status 1
Error: error building at STEP "RUN apt-get update": error while running runtime: exit status 1
npm ERR! code 125
npm ERR! path /home/admin/STAOJ/executioner
npm ERR! command failed
npm ERR! command sh /tmp/postinstall-6dd92697.sh

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/admin/.npm/_logs/2022-09-01T03_30_06_112Z-debug-0.log
```

This error wasn't here before so I'm not sure why it's here now. I also don't know what the command arg does but it seems to fix the problem. 
