### PR TITLE
Stop error propagation

### DIFF
--- a/executioner/src/executioner.mjs
+++ b/executioner/src/executioner.mjs
@@ -132,7 +132,7 @@ export async function runExecutioner(
         } else {
           await sendMessage(new Message(request.id, state.error));
         }
-        throw e;
+        console.error(e);
       } finally {
         // Regardless, run the next queued request if any
         const it = executingRequests.indexOf(request.id);


### PR DESCRIPTION
The reason to not propagate the error is that the handler above crashes the program (with cleanup procedure). I think it'd be better if the executioner just ignores the error and move on to the next one.
