### PR TITLE
Use Alpine

### DIFF
--- a/executioner/Dockerfile
+++ b/executioner/Dockerfile
@@ -1,13 +1,8 @@
-FROM ubuntu:22.04
+FROM alpine:3.16
 
 # Add dependencies via package manager
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y make build-essential
-RUN apt-get install -y openjdk-11-jre openjdk-11-jdk
-RUN apt-get install -y ruby
-RUN apt-get install -y nodejs
-RUN apt-get install -y rustc
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y mono-complete
+RUN apk add gcc g++ make openjdk11 ruby nodejs rust curl
+RUN apk add "mono=6.12.0.182-r0" --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
 
 WORKDIR /app
 


### PR DESCRIPTION
Alpine is awesome. It's fast, lightweight and easy to lock version (resolves #48). Every package version in a specific alpine version is locked (except for mono because mono sucks). 

Alpine built in 37.5s where as ubuntu built in 85.7s.

@Daniel5055 Can you run the tests? I am having a bit of trouble running the tests on my computer for some weird reason. 